### PR TITLE
diag: properly format numbers >1G

### DIFF
--- a/smaps/diag
+++ b/smaps/diag
@@ -59,7 +59,6 @@ sub num
 	return sprintf("%8.1lf k", $n) if $n < 1024;
 	$n /= 1024;
 	return sprintf("%8.1lf M", $n) if $n < 1024;
-	$n /= 1024;
 	return sprintf("%8.1lf G", $n / 1024);
 }
 


### PR DESCRIPTION
Previously, sizes > 1GiB were being divided by 1024 one time too many before printing, so any quantity between 1 GiB and 102.4 GiB would be reported as 0.0 G.