### PR TITLE
Experimental %s on scalar is now forbidden

### DIFF
--- a/smaps/diag
+++ b/smaps/diag
@@ -34,7 +34,7 @@ sub summarize
 	my %sum;
 	for my $m (@_) {
 		$sum{$m->{path}}{usage}{$_} += $m->{usage}{$_}
-			for keys $m->{usage};
+			for keys %{ $m->{usage} };
 	}
 	return \%sum;
 }
@@ -47,7 +47,7 @@ sub dumbdown
 		$path = '[stack]' if $path =~ m{^\[stack};
 		$path = '[mmap]'  if $path =~ m{^/};
 		$sum{$path}{usage}{$_} += $m->{usage}{$_}
-			for keys $m->{usage};
+			for keys %{ $m->{usage} };
 	}
 	return \%sum;
 }


### PR DESCRIPTION
An experimental feature added in Perl 5.14 allowed each
keys, push, pop, shift, splice, unshift, and values to be
called with a scalar argument. This experiment is
considered unsuccessful, and has been removed

Use postdereferencing instead

Signed-off-by: Khem Raj <raj.khem@gmail.com>